### PR TITLE
Refactor ItemProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ implementation could look like:
 require 'bulk_processor/csv_processor'
 
 class PetCSVProcessor < BulkProcessor::CSVProcessor
+  # Note: this must be overridden in a subclass
+  #
   # @return [Array<String>] column headers that must be present
   def self.required_columns
     ['species', 'name', 'age']
@@ -86,6 +88,8 @@ class PetCSVProcessor < BulkProcessor::CSVProcessor
     ['favorite_toy', 'talents']
   end
 
+  # Note: this must be overridden in a subclass
+  #
   # @return [RowProcessor] a class that implements the RowProcessor role
   def self.row_processor_class
     PetRowProcessor

--- a/lib/bulk_processor/config.rb
+++ b/lib/bulk_processor/config.rb
@@ -1,4 +1,5 @@
 class BulkProcessor
+  # Store configuration data set by clients
   class Config
     attr_reader :queue_adapter
 

--- a/lib/bulk_processor/csv_processor.rb
+++ b/lib/bulk_processor/csv_processor.rb
@@ -75,6 +75,10 @@ class BulkProcessor
       handler.complete!
     rescue Exception => exception
       handler.fail!(exception)
+
+      # Swallow any StandardError, since we are already reporting it to the
+      # user. However, we must re-raise Exceptions, such as SIGTERMs since they
+      # need to be handled at a level above this gem.
       raise unless exception.is_a?(StandardError)
     end
 

--- a/lib/bulk_processor/csv_processor.rb
+++ b/lib/bulk_processor/csv_processor.rb
@@ -1,0 +1,92 @@
+class BulkProcessor
+  # An abstract implmentation of the CSVProcessor role. Provides
+  #
+  #   * A default implementation of `.optional_columns`, returning []
+  #   * An initializer that assigns the arguments as instance attributes
+  #   * An implementation of #start to cover a common use case
+  #
+  # The common use case cover by this class' implementation of `#start` is
+  #
+  #   1. Iteratively process each record
+  #   2. Accumulate the results (did the processing succeed? what were the error
+  #      messages?)
+  #   3. Send the results to an instance of the Handler role.
+  #
+  # This class adds 2 required class methods that must be overridden in any
+  # subclass
+  #
+  #   * row_processor_class - returns the class that implements the RowProcessor
+  #     role to process rows of the CSV
+  #   * handler_class - returns the class that implements the Handler role,
+  #     which handles completion (or failure) of processing the entire CSV
+  #
+  # The `required_columns` method must still be implemented in a subclass
+  #
+  class CSVProcessor
+    # @return [RowProcessor] a class that implements the RowProcessor interface
+    def self.row_processor_class
+      raise NotImplementedError,
+            "#{self.class.name} must implement #{__method__}"
+    end
+
+    # @return [Handler] a class that implements the Handler role
+    def self.handler_class
+      raise NotImplementedError,
+            "#{self.class.name} must implement #{__method__}"
+    end
+
+    # @return [Array<String>] column headers that must be present
+    def self.required_columns
+      raise NotImplementedError,
+            "#{self.class.name} must implement #{__method__}"
+    end
+
+    # @return [Array<String>] column headers that may be present. If a column
+    #   header is present that is not in 'required_columns' or
+    #   'optional_columns', the file will be considered invalid and no rows will
+    #   be processed.
+    def self.optional_columns
+      []
+    end
+
+    def initialize(records, payload: {})
+      @records = records
+      @payload = payload
+      @successes = {}
+      @errors = {}
+    end
+
+    # Iteratively process each record, accumulate the results, and pass those
+    # off to the handler. If an unrescued error is raised for any record,
+    # processing will halt for all remaining records and the `#fail!` will be
+    # invoked on the handler.
+    def start
+      records.each_with_index do |record, index|
+        processor = row_processor(record)
+        processor.process!
+        if processor.success?
+          successes[index] = processor.messages
+        else
+          errors[index] = processor.messages
+        end
+      end
+      handler.complete!
+    rescue Exception => exception
+      handler.fail!(exception)
+      raise unless exception.is_a?(StandardError)
+    end
+
+    private
+
+    attr_reader :records, :payload, :successes, :errors
+
+    def handler
+      self.class.handler_class.new(payload: payload, successes: successes,
+                                   errors: errors)
+    end
+
+    def row_processor(record)
+      self.class.row_processor_class.new(record, payload: payload)
+    end
+  end
+end

--- a/lib/bulk_processor/csv_processor.rb
+++ b/lib/bulk_processor/csv_processor.rb
@@ -1,3 +1,5 @@
+require_relative 'no_op_handler'
+
 class BulkProcessor
   # An abstract implmentation of the CSVProcessor role. Provides
   #
@@ -12,13 +14,14 @@ class BulkProcessor
   #      messages?)
   #   3. Send the results to an instance of the Handler role.
   #
-  # This class adds 2 required class methods that must be overridden in any
+  # This class adds 2 required class methods that can be overridden in any
   # subclass
   #
-  #   * row_processor_class - returns the class that implements the RowProcessor
-  #     role to process rows of the CSV
-  #   * handler_class - returns the class that implements the Handler role,
-  #     which handles completion (or failure) of processing the entire CSV
+  #   * row_processor_class - (required) Returns the class that implements the
+  #     RowProcessor role to process rows of the CSV
+  #   * handler_class - (optional) Returns the class that implements the Handler
+  #     role,  which handles results from the completion (or failure) of
+  #     processing the entire CSV.
   #
   # The `required_columns` method must still be implemented in a subclass
   #
@@ -31,8 +34,7 @@ class BulkProcessor
 
     # @return [Handler] a class that implements the Handler role
     def self.handler_class
-      raise NotImplementedError,
-            "#{self.class.name} must implement #{__method__}"
+      NoOpHandler
     end
 
     # @return [Array<String>] column headers that must be present

--- a/lib/bulk_processor/job.rb
+++ b/lib/bulk_processor/job.rb
@@ -1,26 +1,13 @@
+require 'active_job'
+
 class BulkProcessor
+  # ActiveJob to handle processing the CSV in the background
   class Job < ActiveJob::Base
     queue_as 'bulk_processor'
 
-    def perform(records, item_proccessor, handler, payload)
-      item_proccessor_class = item_proccessor.constantize
-      handler_class = handler.constantize
-
-      successes = {}
-      failures = {}
-      records.each_with_index do |record, index|
-        processor = item_proccessor_class.new(record, payload)
-        processor.process!
-        if processor.success?
-          successes[index] = processor.messages
-        else
-          failures[index] = processor.messages
-        end
-      end
-      handler_class.complete(payload, successes, failures, nil)
-    rescue Exception => exception
-      handler_class.complete(payload, successes, failures, exception)
-      raise unless exception.is_a?(StandardError)
+    def perform(records, processor_class, payload)
+      processor = processor_class.constantize.new(records, payload: payload)
+      processor.start
     end
   end
 end

--- a/lib/bulk_processor/no_op_handler.rb
+++ b/lib/bulk_processor/no_op_handler.rb
@@ -1,0 +1,12 @@
+class BulkProcessor
+  class NoOpHandler
+    def initialize(*)
+    end
+
+    def complete!
+    end
+
+    def fail!(*)
+    end
+  end
+end

--- a/lib/bulk_processor/no_op_handler.rb
+++ b/lib/bulk_processor/no_op_handler.rb
@@ -1,12 +1,12 @@
 class BulkProcessor
   class NoOpHandler
-    def initialize(*)
+    def initialize(payload:, successes:, errors:)
     end
 
     def complete!
     end
 
-    def fail!(*)
+    def fail!(fatal_error)
     end
   end
 end

--- a/lib/bulk_processor/version.rb
+++ b/lib/bulk_processor/version.rb
@@ -1,3 +1,3 @@
 class BulkProcessor
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/bulk_processor/csv_processor_spec.rb
+++ b/spec/bulk_processor/csv_processor_spec.rb
@@ -1,0 +1,47 @@
+require 'bulk_processor/csv_processor'
+
+describe BulkProcessor::CSVProcessor do
+  class TestCSVProcessor < BulkProcessor::CSVProcessor
+  end
+
+  before do
+    allow(TestCSVProcessor).to receive(:row_processor_class)
+      .and_return(MockRowProcessor)
+    allow(TestCSVProcessor).to receive(:handler_class).and_return(MockHandler)
+  end
+
+  it_behaves_like 'a role', 'CSVProcessor'
+
+  describe '#start' do
+    subject { TestCSVProcessor.new(records, payload: payload) }
+
+    let(:records) { [{ 'name' => 'Rex' }, { 'name' => 'Fido' }] }
+    let(:payload) { { 'relevant' => 'data' } }
+    let(:row_processor_1) do
+      instance_double(BulkProcessor::Role::RowProcessor, process!: true,
+                                                         success?: true,
+                                                         messages: [])
+    end
+    let(:row_processor_2) do
+      instance_double(BulkProcessor::Role::RowProcessor, process!: true,
+                                                         success?: true,
+                                                         messages: [])
+    end
+
+    before do
+      allow(MockRowProcessor).to receive(:new)
+        .with({ 'name' => 'Rex' }, payload: payload)
+        .and_return(row_processor_1)
+      allow(MockRowProcessor).to receive(:new)
+        .with({ 'name' => 'Fido' }, payload: payload)
+        .and_return(row_processor_2)
+      allow(MockHandler).to receive(:complete)
+    end
+
+    it 'processes all records' do
+      expect(row_processor_1).to receive(:process!)
+      expect(row_processor_2).to receive(:process!)
+      subject.start
+    end
+  end
+end

--- a/spec/bulk_processor/job_spec.rb
+++ b/spec/bulk_processor/job_spec.rb
@@ -1,15 +1,17 @@
 describe BulkProcessor::Job do
-  context 'when a SIGTERM is received' do
+  describe '#perform' do
+    let(:csv_processor) { instance_double(BulkProcessor::Role::CSVProcessor) }
+    let(:records) { [{ 'species' => 'dog' }] }
+    let(:payload) { { 'other' => 'data' } }
+
     before do
-      allow_any_instance_of(MockItemProcessor)
-        .to receive(:process!).and_raise(SignalException, 'SIGTERM')
+      allow(MockCSVProcessor).to receive(:new)
+        .with(records, payload: payload).and_return(csv_processor)
     end
 
-    it 're-raises the SignalException' do
-      expect do
-        job = BulkProcessor::Job.new
-        job.perform([{ 'species' => 'dog' }], 'MockItemProcessor', 'TestHandler', {})
-      end.to raise_error(SignalException)
+    it 'starts a new CSVProcessor instance' do
+      expect(csv_processor).to receive(:start)
+      subject.perform(records, 'MockCSVProcessor', payload)
     end
   end
 end

--- a/spec/bulk_processor/no_op_handler_spec.rb
+++ b/spec/bulk_processor/no_op_handler_spec.rb
@@ -1,0 +1,3 @@
+describe BulkProcessor::NoOpHandler do
+  it_behaves_like 'a role', 'Handler'
+end

--- a/spec/bulk_processor/validated_csv_spec.rb
+++ b/spec/bulk_processor/validated_csv_spec.rb
@@ -70,4 +70,22 @@ describe BulkProcessor::ValidatedCSV do
       expect(subject.row_hashes).to eq([])
     end
   end
+
+  context 'with header that is all whitespace' do
+    let(:csv_str) { "name, ,age\nRex,1" }
+
+    it 'is not valid' do
+      expect(subject).to_not be_valid
+    end
+
+    it 'provides a useful error message' do
+      subject.valid?
+      expect(subject.errors)
+        .to include('Missing or malformed column header, is one of them blank?')
+    end
+
+    it 'has empty row_hashes' do
+      expect(subject.row_hashes).to eq([])
+    end
+  end
 end

--- a/spec/bulk_processor_spec.rb
+++ b/spec/bulk_processor_spec.rb
@@ -77,11 +77,8 @@ describe BulkProcessor do
 
       it 'calls #fail! with the fatal error' do
         perform_enqueued_jobs do
-          begin
-            expect(handler).to receive(:fail!).with(instance_of(StandardError))
-            subject.start
-          rescue SignalException
-          end
+          expect(handler).to receive(:fail!).with(instance_of(StandardError))
+          subject.start
         end
       end
     end

--- a/spec/support/mock_csv_processor.rb
+++ b/spec/support/mock_csv_processor.rb
@@ -1,0 +1,15 @@
+require 'bulk_processor/csv_processor'
+
+class MockCSVProcessor < BulkProcessor::CSVProcessor
+  def self.required_columns
+    []
+  end
+
+  def self.row_processor_class
+    MockRowProcessor
+  end
+
+  def self.handler_class
+    MockHandler
+  end
+end

--- a/spec/support/mock_handler.rb
+++ b/spec/support/mock_handler.rb
@@ -1,4 +1,10 @@
 class MockHandler
-  def self.complete(_payload, _success, _errors, _fatal_error)
+  def initialize(payload:, successes:, errors:)
+  end
+
+  def complete!
+  end
+
+  def fail!(fatal_error)
   end
 end

--- a/spec/support/mock_row_processor.rb
+++ b/spec/support/mock_row_processor.rb
@@ -1,16 +1,7 @@
-class MockItemProcessor
-  cattr_writer :required_columns, :optional_columns
+class MockRowProcessor
   attr_reader :record, :messages
 
-  def self.required_columns
-    @@required_columns || []
-  end
-
-  def self.optional_columns
-    @@optional_columns || []
-  end
-
-  def initialize(record, _payload)
+  def initialize(record, payload:)
     @record = record
     @success = false
     @messages = []

--- a/spec/support/mock_row_processor.rb
+++ b/spec/support/mock_row_processor.rb
@@ -1,25 +1,12 @@
 class MockRowProcessor
-  attr_reader :record, :messages
+  attr_reader :messages
 
   def initialize(record, payload:)
-    @record = record
-    @success = false
-    @messages = []
   end
 
   def process!
-    case record['name']
-    when 'Rex'
-      @success = true
-    when 'Human'
-      raise 'bad human'
-    else
-      @success = false
-      @messages << 'bad dog'
-    end
   end
 
   def success?
-    @success
   end
 end

--- a/spec/support/role/csv_processor.rb
+++ b/spec/support/role/csv_processor.rb
@@ -8,7 +8,7 @@ class BulkProcessor
       def self.optional_columns
       end
 
-      def initialize(records, payload: payload)
+      def initialize(records, payload:)
       end
 
       def start

--- a/spec/support/role/csv_processor.rb
+++ b/spec/support/role/csv_processor.rb
@@ -1,0 +1,17 @@
+class BulkProcessor
+  module Role
+    class CSVProcessor
+      def self.required_columns
+      end
+
+      def self.optional_columns
+      end
+
+      def initialize(record, payload: payload)
+      end
+
+      def start
+      end
+    end
+  end
+end

--- a/spec/support/role/csv_processor.rb
+++ b/spec/support/role/csv_processor.rb
@@ -1,5 +1,6 @@
 class BulkProcessor
   module Role
+    # Role used by BulkProcessor::Job to process a set of records from a CSV.
     class CSVProcessor
       def self.required_columns
       end
@@ -7,7 +8,7 @@ class BulkProcessor
       def self.optional_columns
       end
 
-      def initialize(record, payload: payload)
+      def initialize(records, payload: payload)
       end
 
       def start

--- a/spec/support/role/handler.rb
+++ b/spec/support/role/handler.rb
@@ -1,5 +1,8 @@
 class BulkProcessor
   module Role
+    # Role used by BulkProcessor::CSVProcessor (itself an abstract
+    # implementation of the CSVProcessor role) to report on the results (or
+    # failure) of processing a CSV file.
     class Handler
       def initialize(payload:, successes:, errors:)
       end

--- a/spec/support/role/handler.rb
+++ b/spec/support/role/handler.rb
@@ -1,0 +1,14 @@
+class BulkProcessor
+  module Role
+    class Handler
+      def initialize(payload:, successes:, errors:)
+      end
+
+      def complete!
+      end
+
+      def fail!(fatal_error)
+      end
+    end
+  end
+end

--- a/spec/support/role/row_processor.rb
+++ b/spec/support/role/row_processor.rb
@@ -1,0 +1,17 @@
+class BulkProcessor
+  module Role
+    class RowProcessor
+      def initialize(record, payload: payload)
+      end
+
+      def process!
+      end
+
+      def success?
+      end
+
+      def messages
+      end
+    end
+  end
+end

--- a/spec/support/role/row_processor.rb
+++ b/spec/support/role/row_processor.rb
@@ -3,7 +3,7 @@ class BulkProcessor
     # Role used by BulkProcessor::CSVProcessor (itself an abstract
     # implementation of the CSVProcessor role) to process an individual CSV row.
     class RowProcessor
-      def initialize(record, payload: payload)
+      def initialize(record, payload:)
       end
 
       def process!

--- a/spec/support/role/row_processor.rb
+++ b/spec/support/role/row_processor.rb
@@ -1,5 +1,7 @@
 class BulkProcessor
   module Role
+    # Role used by BulkProcessor::CSVProcessor (itself an abstract
+    # implementation of the CSVProcessor role) to process an individual CSV row.
     class RowProcessor
       def initialize(record, payload: payload)
       end

--- a/spec/support/shared_examples/role.rb
+++ b/spec/support/shared_examples/role.rb
@@ -1,0 +1,17 @@
+shared_examples_for 'a role' do |role|
+  role_class = BulkProcessor::Role.const_get(role)
+
+  context "a #{role} role" do
+    role_class.methods(false).each do |class_method|
+      it "responds to .#{class_method}" do
+        expect(described_class).to respond_to(class_method)
+      end
+    end
+
+    role_class.instance_methods(false).each do |instance_method|
+      it "responds to ##{instance_method}" do
+        expect(described_class.instance_methods).to include(instance_method)
+      end
+    end
+  end
+end


### PR DESCRIPTION
@kristjan @jrichard

Break the `ItemProcessor` role into the `CSVProcessor` and `RowProcessor` roles. A class implementing `CSVProcessor` takes in the entire CSV (represented as an `Array` of `Hashes`) and processes it with an invocation of the `#start` method.

A base class (`BulkProcessor::CSVProcessor`) is provided to help build for a common use case. This class implements the `#start` method, which will iterate over each row with a `RowProcessor`. When all rows have been processed, it passes the results to an instance of the `Handler` role.

See the <a href="https://github.com/apartmentlist/bulk-processor/tree/preserve-csv#bulkprocessor">README</a> or `spec/support/roles` from more details on these roles.