### PR TITLE
Fix content encoding bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.1.5
-  - 2.2.3
+  - 2.3.4
+  - 2.4.2
 branches:
   only: master

--- a/bulk-processor.gemspec
+++ b/bulk-processor.gemspec
@@ -26,7 +26,7 @@ success or failure report
 
   spec.add_development_dependency 'activejob', '~> 4'
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'dynosaur', '~> 0.2.1'
+  spec.add_development_dependency 'dynosaur', '~> 0.3'
   spec.add_development_dependency 'pry-byebug', '~> 3'
   spec.add_development_dependency 'rake', '~> 10.4'
   spec.add_development_dependency 'rspec', '~> 3.3'

--- a/lib/bulk_processor/s3_file.rb
+++ b/lib/bulk_processor/s3_file.rb
@@ -26,7 +26,8 @@ class BulkProcessor
     # @yields [File] a local copy of the remote file
     def open
       with_temp_file do |local_file|
-        client.get_object({ bucket: bucket, key: key }, target: local_file)
+        object = client.get_object(bucket: bucket, key: key)
+        local_file.write(object.body.read)
         local_file.rewind
         yield local_file
       end

--- a/lib/bulk_processor/version.rb
+++ b/lib/bulk_processor/version.rb
@@ -1,3 +1,3 @@
 class BulkProcessor
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.7.1'.freeze
 end

--- a/spec/bulk_processor/s3_file_spec.rb
+++ b/spec/bulk_processor/s3_file_spec.rb
@@ -47,17 +47,25 @@ describe BulkProcessor::S3File do
   end
 
   describe '#open' do
+    let(:response) do
+      instance_double(
+        Aws::S3::Types::GetObjectOutput,
+        body: StringIO.new('test file contents')
+      )
+    end
+
+    before do
+      allow(s3_client).to receive(:get_object).with({ bucket: bucket, key: modified_key })
+        .and_return(response)
+    end
+
     it 'gets the object from the bucket with the correct key' do
-      expect(s3_client).to receive(:get_object)
-        .with({ bucket: bucket, key: modified_key }, anything)
+      expect(s3_client).to receive(:get_object).with({ bucket: bucket, key: modified_key })
+        .and_return(response)
       subject.open {}
     end
 
     it 'yields a local copy of the remote file' do
-      def s3_client.get_object(_config, opts)
-        opts[:target].write('test file contents')
-      end
-
       yielded_contents = 'deadbeef'
       subject.open do |file|
         yielded_contents = file.read


### PR DESCRIPTION
`Aws::S3::Client#get_object` doesn't handle all character encodings well when told to write to an explicit target file. However, the body of the object returned can be read, then written to a local file without crashing on the same characters.