### PR TITLE
Update AWS-SDK gem to v3 in gemfile

### DIFF
--- a/bulk-processor.gemspec
+++ b/bulk-processor.gemspec
@@ -21,7 +21,7 @@ success or failure report
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_runtime_dependency 'aws-sdk', '~> 2.1'
+  spec.add_runtime_dependency 'aws-sdk', '~> 3'
   spec.add_runtime_dependency 'rack', '~> 1.5'
 
   spec.add_development_dependency 'activejob', '~> 4'


### PR DESCRIPTION
Updated AWS-SDK to version 3 because alkalign depends on AWS-SDK-core v3. v2 to v3 should be a clean update based on https://docs.aws.amazon.com/sdk-for-ruby/v3/api/index.html

