### PR TITLE
Dependent gem update

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Version 0.7.3, 2018-06-01
+-------------------------
+1b01dd0 Update AWS-SDK gem
+
 Version 0.7.2, 2018-05-31
 -------------------------
 6f30c21 Update version number of Bulk Processor

--- a/bulk-processor.gemspec
+++ b/bulk-processor.gemspec
@@ -21,7 +21,7 @@ success or failure report
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_runtime_dependency 'aws-sdk', '~> 3'
+  spec.add_runtime_dependency 'aws-sdk-s3'
   spec.add_runtime_dependency 'rack', '~> 1.5'
 
   spec.add_development_dependency 'activejob', '~> 4'

--- a/lib/bulk_processor/s3_file.rb
+++ b/lib/bulk_processor/s3_file.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 class BulkProcessor
   # Read and write files in a pre-configured S3 bucket.

--- a/lib/bulk_processor/version.rb
+++ b/lib/bulk_processor/version.rb
@@ -1,3 +1,3 @@
 class BulkProcessor
-  VERSION = '0.7.2'.freeze
+  VERSION = '0.7.3'.freeze
 end


### PR DESCRIPTION
When gem AWS-SDK upgraded from v2 to v3 it became modularized and then installed 70+ unnecessary gems. This commit only installs the singular needed gem from the aws-sdk family. 