### PR TITLE
add bundle exec before rake

### DIFF
--- a/lib/bulk_processor/back_end/gcp.rb
+++ b/lib/bulk_processor/back_end/gcp.rb
@@ -8,8 +8,8 @@ class BulkProcessor
         @payload = PayloadSerializer.serialize(payload)
         @key = key
 
-        GcpManager.add_task('start-bulk-processor', 'rake bulk_processor_gcp_pods:start')
-        GcpManager.add_task('split-bulk-processor', 'rake bulk_processor_gcp_pods:split')
+        GcpManager.add_task('start-bulk-processor', 'bundle exec rake bulk_processor_gcp_pods:start')
+        GcpManager.add_task('split-bulk-processor', 'bundle exec rake bulk_processor_gcp_pods:split')
       end
 
       def start


### PR DESCRIPTION
bulk processing is broken because of missing `bundle exec` before `rake`
https://app.datadoghq.com/logs?cols=core_host%2Ccore_service&from_ts=1617825908748&index=&live=true&messageDisplay=inline&query=pod_name%3Astart-bulk-processor-4040bd6528d39e127d336ed3be28e2e2-tv674&stream_sort=desc&to_ts=1617998708748&event=AQAAAXi0CIdi7xB1cAAAAABBWGkwQ0lzMEFBRGR4aDkwajBIQnJBQUM