### PR TITLE
REV-889 update file deletion logic

### DIFF
--- a/lib/bulk_processor/process_csv.rb
+++ b/lib/bulk_processor/process_csv.rb
@@ -13,8 +13,6 @@ class BulkProcessor
         processor = processor_class.new(csv, payload: payload.merge('key' => key))
         processor.start
       end
-    ensure
-      file.try(:delete)
     end
 
     private

--- a/lib/bulk_processor/split_csv.rb
+++ b/lib/bulk_processor/split_csv.rb
@@ -16,8 +16,6 @@ class BulkProcessor
     rescue Exception => error
       handle_error(error)
       raise
-    ensure
-      BulkProcessor.config.file_class.new(key).delete
     end
 
     private

--- a/lib/bulk_processor/version.rb
+++ b/lib/bulk_processor/version.rb
@@ -1,3 +1,3 @@
 class BulkProcessor
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/lib/jobs/process_csv_job.rb
+++ b/lib/jobs/process_csv_job.rb
@@ -2,13 +2,24 @@ require 'sidekiq'
 
 class ProcessCSVJob
   include Sidekiq::Worker
-  sidekiq_options queue: 'medium'
+  sidekiq_options queue: 'medium', retry: 0
 
   def perform(processor_class, payload, key)
-    BulkProcessor::ProcessCSV.new(
-      processor_class.constantize,
-      BulkProcessor::PayloadSerializer.deserialize(payload),
-      key
-    ).perform
+    retry_limit = 3
+    begin
+      BulkProcessor::ProcessCSV.new(
+        processor_class.constantize,
+        BulkProcessor::PayloadSerializer.deserialize(payload),
+        key
+      ).perform
+    rescue Exception => e
+      if retry_limit > 0
+        retry_limit -= 1
+        retry
+      end
+      raise e
+    ensure
+      BulkProcessor.config.file_class.new(key).delete
+    end
   end
 end

--- a/lib/jobs/split_csv_job.rb
+++ b/lib/jobs/split_csv_job.rb
@@ -2,14 +2,25 @@ require 'sidekiq'
 
 class SplitCSVJob
   include Sidekiq::Worker
-  sidekiq_options queue: 'medium'
+  sidekiq_options queue: 'medium', retry: 0
 
   def perform(processor_class, payload, key, num_chunks)
-    BulkProcessor::SplitCSV.new(
-      processor_class.constantize,
-      BulkProcessor::PayloadSerializer.deserialize(payload),
-      key,
-      num_chunks
-    ).perform
+    retry_limit = 3
+    begin
+      BulkProcessor::SplitCSV.new(
+        processor_class.constantize,
+        BulkProcessor::PayloadSerializer.deserialize(payload),
+        key,
+        num_chunks
+      ).perform
+    rescue Exception => e
+      if retry_limit > 0
+        retry_limit -= 1
+        retry
+      end
+      raise e
+    ensure
+      BulkProcessor.config.file_class.new(key).delete
+    end
   end
 end

--- a/spec/bulk_processor/process_csv_spec.rb
+++ b/spec/bulk_processor/process_csv_spec.rb
@@ -23,9 +23,9 @@ describe BulkProcessor::ProcessCSV do
       subject.perform
     end
 
-    it 'removes the file' do
+    it 'does not remove the file' do
       subject.perform
-      expect(MockFile.new('file.csv')).to_not exist
+      expect(MockFile.new('file.csv')).to exist
     end
 
     context 'when processing raises an error' do

--- a/spec/bulk_processor/split_csv_spec.rb
+++ b/spec/bulk_processor/split_csv_spec.rb
@@ -27,9 +27,9 @@ describe BulkProcessor::SplitCSV do
         subject.perform
       end
 
-      it 'removes the file' do
+      it 'not remove the file' do
         subject.perform
-        expect(MockFile.new('file.csv')).to_not exist
+        expect(MockFile.new('file.csv')).to exist
       end
 
       context 'when starting a processing job raises an error' do


### PR DESCRIPTION
Updating the file deletion logic so that the temp file will only be deleted after the retrying limit of the job has been hit