### PR TITLE
REV-906 Fix bug in Pre Processor results

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Version 1.1.1, 2022-11-28
+-------------------------
+Added in PreProcessor. Fixed bugs.
+
 Version 0.8.7, 2022-06-06
 -------------------------
 No functional changes. Updating build pipeline to publish to GitHub Packages.

--- a/lib/bulk_processor/csv_processor.rb
+++ b/lib/bulk_processor/csv_processor.rb
@@ -84,7 +84,7 @@ class BulkProcessor
     def start
       pre_processes
       if self.class.pre_processor_class.fail_process_if_failed && results.present?
-        raise StandardError, results.join(". ")
+        handler.complete!
       else
         row_processors.each do |processor|
           processor.process!

--- a/lib/bulk_processor/version.rb
+++ b/lib/bulk_processor/version.rb
@@ -1,3 +1,3 @@
 class BulkProcessor
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.1.1'.freeze
 end

--- a/spec/bulk_processor/csv_processor_spec.rb
+++ b/spec/bulk_processor/csv_processor_spec.rb
@@ -82,8 +82,8 @@ describe BulkProcessor::CSVProcessor do
         allow(MockPreProcessor).to receive(:fail_process_if_failed).and_return(true)
       end
 
-      it 'fail the process' do
-        expect(handler).to receive(:fail!).with(instance_of(StandardError))
+      it 'end the process' do
+        expect(handler).to receive(:complete!)
         subject.start
       end
     end


### PR DESCRIPTION
- If the PreProcessor failed, it should have the results go into the `complete!` method
- The results should be BulkProcessor::CSVProcessor::Result class